### PR TITLE
Enable selection of region.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ pillow = "*"
 imagehash = "*"
 mss = "*"
 gooey = "*"
+pygi = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,8 @@ imagehash = "*"
 mss = "*"
 gooey = "*"
 pygi = "*"
+pycairo = "*"
+pygobject = "*"
 
 [requires]
 python_version = "3.8"

--- a/region_selector.py
+++ b/region_selector.py
@@ -1,0 +1,116 @@
+import cairo
+import gi
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
+ret_regions = []
+used_display = 0
+
+class RegionWindow(Gtk.ApplicationWindow):
+  is_first_select = True
+  rectangle_start = (0,0)
+  rectangle_end= (0,0)
+  monitor_geo = (0,0)
+
+  def __init__(self, app):
+    # instantiate
+    self.box = Gtk.Box()
+    self.d = Gtk.DrawingArea()
+    self.box.pack_start(self.d, True, True, 0)
+    self.d.set_can_focus(True)
+    self.box.set_can_focus(True)
+
+    # decoration
+    Gtk.ApplicationWindow.__init__(self, application = app)
+    self.set_border_width(0)
+    self.set_app_paintable(True)
+    self.set_decorated(False)
+    self.set_property("skip-taskbar-hint", True)
+    self.connect("draw", self.draw)
+
+
+    # register cbs
+    self.connect("button-press-event", self.mouse_press)
+    self.connect("button-release-event", self.mouse_release)
+    self.connect("motion-notify-event", self.motion_notify)
+    self.connect("key-press-event", self.key_press)
+
+    # size/color
+    screen = self.get_screen()
+    monitor = screen.get_monitor_geometry(used_display)
+    visual = screen.get_rgba_visual()
+    if visual and screen.is_composited():
+      self.set_visual(visual)
+
+    geo_x = monitor.x
+    geo_y = monitor.y
+    width = screen.width()
+    height = screen.height()
+    self.d.set_size_request(width, height)
+    self.monitor_geo = (geo_x, geo_y)
+    self.move(geo_x, geo_y)
+    self.fullscreen()
+
+    # show
+    self.add(self.box)
+    self.show_all()
+
+    self.set_keep_above(True)
+    self.grab_focus()
+
+  def return_area(self):
+    global ret_regions
+    ret_regions = [
+      (self.rectangle_start[0] + self.monitor_geo[0], self.rectangle_start[1] + self.monitor_geo[1]),
+      (self.rectangle_end[0] + self.monitor_geo[0], self.rectangle_end[1] + self.monitor_geo[1])
+      ]
+    self.close()
+
+  def key_press(self, widget, context):
+    (_, key) = context.get_keycode()
+    if key == 36:
+      self.return_area()
+
+  def motion_notify(self, widget, context):
+    if self.is_first_select:      # dirty workaround for MacOS
+      self.is_first_select = False
+      self.rectangle_start = (context.x, context.y)
+    self.rectangle_end = (context.x, context.y)
+    if self.rectangle_start == self.rectangle_end:
+      return
+    widget.queue_draw()
+
+  def mouse_press(self, widget, context):
+    self.rectangle_start = (context.x, context.y)
+    self.rectangle_end = (context.x+1, context.y+1)
+    widget.queue_draw()
+
+  def mouse_release(self, widget, context):
+    self.rectangle_end = (context.x, context.y)
+    widget.queue_draw()
+
+  def draw(self, widget, context):
+    context.set_source_rgba(0, 0, 0, 0.5)
+    context.set_operator(cairo.OPERATOR_SOURCE)
+    context.paint()
+    context.set_operator(cairo.OPERATOR_OVER)
+
+    context.set_line_width(1)
+    context.set_source_rgb(1.0, 1.0, 1.0)
+    context.rectangle(self.rectangle_start[0], self.rectangle_start[1], self.rectangle_end[0] - self.rectangle_start[0], self.rectangle_end[1] - self.rectangle_start[1])
+    context.stroke()
+
+
+class RegionSelector(Gtk.Application):
+  def __init__(self):
+    Gtk.Application.__init__(self, application_id = "github.com.rita-rita-ritan.AutoScreenCapture")
+
+  def do_activate(self):
+    RegionWindow(self)
+
+def get_region(monitor):
+  global used_display
+  used_display = monitor
+  app = RegionSelector()
+  app.run()
+  return ret_regions

--- a/screencapture.py
+++ b/screencapture.py
@@ -7,6 +7,8 @@ import mss
 import pathlib
 from gooey import Gooey, GooeyParser
 
+import region_selector
+
 def init_saved_image_number(directory):
     # 前回と同じディレクトリに再び保存する場合に、前回の保存写真の後に続くようにナンバリングする
     # When saving again to the same directory as last time,
@@ -18,9 +20,17 @@ def init_saved_image_number(directory):
         saved_image_number += 1
     return saved_image_number
 
-def get_screenshot_image(display):
+def get_screenshot_image(display, region = None):
     with mss.mss() as sct:
-        sct_img = sct.grab(sct.monitors[display])
+        if region == None:
+            sct_img = sct.grab(sct.monitors[display])
+        else:
+            top = region[0][1]
+            left = region[0][0]
+            width = region[1][0] - region[0][0]
+            height = region[1][1] - region[0][1]
+            monitor = {"top": int(top), "left": int(left), "width": int(width), "height": int(height)}
+            sct_img = sct.grab(monitor)
         img = Image.frombytes("RGB", sct_img.size, sct_img.bgra, "raw", "BGRX")
         return img
 
@@ -60,10 +70,12 @@ def main():
         default=5)
     parser.add_argument("-d", "--display", type=int,
         help="Display where the screenshot will be taken. 1 is main, 2 secondary, etc. default=1",
-        default=1)
+        default=0)
     parser.add_argument("-m", "--movie_interval", type=int,
         help="(beta) Time interval to save the video. For example, 1 if it is the same as the interval of time to take a screenshot, and 2 if it is twice as long. This option is still in beta, so it may not work properly for you. default=1", 
         default=1)
+    parser.add_argument("-r", "--region-selection", action="store_true",
+        help="(beta) Select screen region to capture. (Ubuntu, OSX)")
 
     args = parser.parse_args()
 
@@ -73,8 +85,16 @@ def main():
     similarity_tolerance = args.similarity_tolerance
     display = args.display
     movie_interval = args.movie_interval
+    region_selection = args.region_selection
 
     subprocess.run(["mkdir", "-p", directory])
+
+    # select region
+    if region_selection:
+        region = region_selector.get_region(display)
+        time.sleep(0.5) # delay
+    else:
+        region = None
 
     print("Directory:", directory)
     print(f"progress: 0/{timeout_minute}")
@@ -86,14 +106,14 @@ def main():
     timeout_second = timeout_minute * 60
     successive_non_similar_count = 0
 
-    current_image = get_screenshot_image(display)
+    current_image = get_screenshot_image(display, region)
     current_image.save(f'{directory}/sct-{saved_image_number}.jpg', 'JPEG')
     print(f"Saved screenshot: sct-{saved_image_number}.jpg\n")
     saved_image_number += 1
     pre_image = current_image
 
     while elapsed_time_second < timeout_second:
-        current_image = get_screenshot_image(display)
+        current_image = get_screenshot_image(display, region)
 
         if is_similar_image(current_image, pre_image, similarity_tolerance):
             successive_non_similar_count = 0


### PR DESCRIPTION
Hello, and thanks for simple, easy-to-use, cute tool!
I implemented a selection of screen region to capture.

## Added Feature
- When `-r` flag is given, it prompts user to select region to capture.
  - as a `[beta]` functionality.
- It takes a screenshot only of selected region.

## Demo
Below demo does:
- start program with `-r` flag, select region, wait a minute, and check a part of result.

https://user-images.githubusercontent.com/47111091/123270445-e0b96d00-d53a-11eb-88cc-5338024ba4c0.mp4


## Environments
I confirmed this patch works on:
- Ubuntu 20.04
- macOS Big Sur v11.4

I haven't check on Windows. In addition, it might not work on other versions of above OSes. Hence I want to add this feature as `beta`.

## NOTE
- I added a dependency in `Pipfile`, but didn't lock `Pipfile.lock`.
